### PR TITLE
FIXED Opacity bug

### DIFF
--- a/lib/mixins/color.coffee
+++ b/lib/mixins/color.coffee
@@ -27,7 +27,7 @@ module.exports =
 
       # CMYK
       else if color.length is 4
-        color = (part / 100 for part in color)    
+        color = (part / 100 for part in color)
     
       return color
       
@@ -67,16 +67,16 @@ module.exports =
     op = if stroke then 'CS' else 'cs'
     @addContent "/#{space} #{op}"
 
-  fillColor: (color, opacity = 1) ->
+  fillColor: (color, opacity) ->
     set = @_setColor color, no
     @fillOpacity opacity if set
     
-    # save this for text wrapper, which needs to reset 
+    # save this for text wrapper, which needs to reset
     # the fill color on new pages
     @_fillColor = [color, opacity]
     return this
 
-  strokeColor: (color, opacity = 1) ->
+  strokeColor: (color, opacity) ->
     set = @_setColor color, yes
     @strokeOpacity opacity if set
     return this
@@ -103,7 +103,7 @@ module.exports =
      if @_opacityRegistry[key]
        [dictionary, name] = @_opacityRegistry[key]
      else
-       dictionary = 
+       dictionary =
          Type: 'ExtGState'
 
        dictionary.ca = fillOpacity if fillOpacity?

--- a/lib/mixins/vector.coffee
+++ b/lib/mixins/vector.coffee
@@ -18,12 +18,13 @@ module.exports =
     @addContent 'Q'
     
   closePath: ->
+    @opacity 1
     @addContent 'h'
   
   lineWidth: (w) ->
     @addContent "#{w} w"
     
-  _CAP_STYLES: 
+  _CAP_STYLES:
     BUTT: 0
     ROUND: 1
     SQUARE: 2


### PR DESCRIPTION
Opacity ONLY worked if we directly called fillColor or strokeColor and
passed an opacity value as the second argument which made all opacity
calls (fillOpacity, strokeOpacity, and opacity) as well as fill,
fillAndStroke, and stroke calls useless if transparency is required.

The issue is that both fillColor and strokeColor automatically set
opacity to the value 1 if no opacity value is passed.  This,
unfortunately, overrides any opacity call made before fill, stroke, or
fillAndStroke since these function invoke the fillColor and strokeColor
functions WITHOUT passing a value for opacity.

The only time opacity would work is if colour was being set incorrectly
(eg. a hex colour value without the ‘#’ at the front) and thus
inheriting from the previous vector’s colours (the set value in both
fillColor and strokeColor would be false and thus opacity is never set)

To fix this, I removed the default value of 1 for opacity for both the
fillColor and strokeColor functions in the color.coffee mixin script.

This doesn’t solve the entire problem however since all subsequent
vector calls will inherit the last set opacity value.  To resolve this,
I added an explicit call to reset the opacity to 1 within the closePath
function in the vector.coffee mixin script.  I am not sure if this is
the best permanent place for this BUT it does resolve the current issue
with opacity.